### PR TITLE
Update for HA Cast

### DIFF
--- a/ui/darksky/dark-sky-weather-card.js
+++ b/ui/darksky/dark-sky-weather-card.js
@@ -1,7 +1,7 @@
 // #####
 // ##### Get the LitElement and HTML classes from an already defined HA Lovelace class
 // #####
-var LitElement = LitElement || Object.getPrototypeOf(customElements.get("home-assistant-main"));
+var LitElement = LitElement || Object.getPrototypeOf(customElements.get("hui-view"));
 var html = LitElement.prototype.html;
 
 // #####


### PR DESCRIPTION
`home-assistant-main` is not available in HA Cast, so Lit would not be available. `hui-view` is.
source -> https://github.com/gurbyz/custom-cards-lovelace/pull/24